### PR TITLE
배포자동화 과정에서 에러가 난 것을 수정하였습니다

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Dependencies   
       run: npm install
     - name: Build               
-      run: npm run build
+      run: CI='' npm run build
 #     - name: Push Contents to S3
 #       run: aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }}
     - name: Deploy to S3


### PR DESCRIPTION
"Treating warnings as errors because process.env.CI = true. Most CI servers set it automatically."
위와 같은 에러가 발생하여 아래와 같이 조치하였습니다
- run: npm run build 를 run: CI='' npm run build 로 수정